### PR TITLE
Docs: Update NixOS Installation to Reflect Module Changes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+# `use devenv` supports the same options as the `devenv shell` command.
+#
+# To silence the output, use `--quiet`.
+#
+# Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,13 @@ pnpm-debug.log*
 .DS_Store
 
 bin/build-deploy
+
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1758218427,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "932c0f2110e7d03a5caa9ffc42bea9f71a022a27",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1758108966,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755783167,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4a880fb247d24fbca57269af672e8f78935b0328",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,6 @@
+{
+  languages.javascript = {
+    enable = true;
+    npm.enable = true;
+  };
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -11,17 +11,21 @@ Installing Noctalia is straightforward and depends on your Linux distribution.
 Choose your installation method:
 
 **Arch Linux:**
+
 1. [AUR Installation (Recommended)](#using-aur-recommended) - Automatic dependency handling
 2. [Development Version](#development-version) - Latest features from Git
 
 **NixOS:**
+
 1. [Quick Run](#quick-run) - Test without installing
 2. [Permanent Installation](#permanent-installation) - Add to system configuration
 
 **Any Distribution:**
+
 1. [Manual Installation](#manual-installation) - Full control over the process
 
 **Compositor Settings:**
+
 1. [Niri](#niri) - Recommended settings to add to your config
 
 After installation, you'll [run Noctalia](#running-noctalia) and set up [keybinds](./keybinds) for the best experience.
@@ -31,15 +35,19 @@ After installation, you'll [run Noctalia](#running-noctalia) and set up [keybind
 ## Arch Linux
 
 ### Using AUR (Recommended)
+
 The simplest way to install Noctalia on Arch Linux is through the Arch User Repository (AUR). This method installs the shell system-wide and handles dependencies automatically.
 
 Please replace with your AUR helper of choice.
+
 ```bash
 paru -S noctalia-shell
 ```
 
 ### Development Version
+
 For the latest features and fixes, you can install the development version directly from the Git repository:
+
 ```bash
 paru -S noctalia-shell
 ```
@@ -52,59 +60,45 @@ The development version may be less stable than the official release. Use this v
 
 ## NixOS
 
-### Quick Run
-Test Noctalia without installing by running it directly:
-```bash
-nix run github:noctalia-dev/noctalia-shell
-```
+### Flake Installation
 
-### Permanent Installation
-For a permanent installation on NixOS, you'll need to add Noctalia to your system configuration.
+For NixOS users, you can add Noctalia to your system configuration using flakes and the provided NixOS module.
 
 **Step 1**: Update your `flake.nix`
 Add the required inputs to your flake configuration:
+
 ```nix
 {
   description = "NixOS configuration with Noctalia";
-  
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    
+
     quickshell = {
       url = "github:outfoxxed/quickshell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    
+
     noctalia = {
       url = "github:noctalia-dev/noctalia-shell";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.quickshell.follows = "quickshell";
+      inputs.quickshell.follows = "quickshell";  # Use same quickshell version
     };
   };
-  
-  outputs = { self, nixpkgs, noctalia, quickshell, ... }: {
+
+  outputs = { self, nixpkgs, noctalia, ... }: {
     nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
       modules = [
         ./configuration.nix
+        noctalia.nixosModules.noctalia  # Import Noctalia module here
       ];
     };
   };
 }
 ```
 
-**Step 2**: Add packages to `configuration.nix`
-Include Noctalia and Quickshell in your system packages:
-```nix
-{ config, pkgs, inputs, ... }:
-{
-  environment.systemPackages = with pkgs; [
-    inputs.noctalia.packages.${system}.default
-    inputs.quickshell.packages.${system}.default
-  ];
-}
-```
+**Step 2**: Rebuild your system
 
-**Step 3**: Rebuild your system
 ```bash
 sudo nixos-rebuild switch --flake .
 ```
@@ -122,6 +116,7 @@ If you prefer to install Noctalia locally or want more control over the installa
 **Step 1**: Install required dependencies
 
 For Arch Linux:
+
 ```bash
 # Core dependencies (required)
 paru -S quickshell ttf-roboto inter-font gpu-screen-recorder brightnessctl
@@ -136,6 +131,7 @@ paru -S cliphist matugen cava wlsunset xdg-desktop-portal
 For other distributions, install the equivalent packages using your package manager.
 
 **Step 2**: Download and install Noctalia
+
 ```bash
 mkdir -p ~/.config/quickshell/noctalia-shell && \
 curl -sL https://github.com/noctalia-dev/noctalia-shell/releases/latest/download/noctalia-latest.tar.gz | \
@@ -145,6 +141,7 @@ tar -xz --strip-components=1 -C ~/.config/quickshell/noctalia-shell
 ### Dependencies Explained
 
 **Required:**
+
 - `quickshell` - Core shell framework
 - `ttf-roboto` - Default UI font
 - `inter-font` - Headers font (clock on LockScreen, etc.)
@@ -152,9 +149,11 @@ tar -xz --strip-components=1 -C ~/.config/quickshell/noctalia-shell
 - `brightnessctl` - Internal/laptop monitor brightness control
 
 **Hardware-specific:**
+
 - `ddcutil` - Desktop monitor brightness control (⚠️ may introduce system instability with certain monitors)
 
 **Optional but recommended:**
+
 - `cliphist` - Clipboard history support
 - `matugen` - Material You color scheme generation
 - `cava` - Audio visualizer component
@@ -192,6 +191,7 @@ layer-rule {
 ```
 
 These settings ensure:
+
 - Proper window activation handling
 - Rounded corners for a modern look
 - Correct backdrop placement for the overview panel
@@ -212,6 +212,7 @@ The configuration files are saved in `~/.config/noctalia/` and the cache files a
 ## Getting Help
 
 If you encounter issues during installation:
+
 - Check our [FAQ](./faq) for common problems
 - Visit our [GitHub Issues](https://github.com/noctalia-dev/noctalia-shell/issues) page
 - Join our community on [Discord](https://discord.noctalia.dev) for real-time support


### PR DESCRIPTION
Updates the NixOS installation documentation to reflect the changes introduced in #302.

## Changes
* Updated installation.mdx to use NixOS module approach
* Removed `nix run` quick test option
* Simplified flake configuration example
* Removed manual package installation step

## Context
Following #302 which introduced the NixOS module with auto-enabled services, the installation documentation needed to be updated to match the new simplified process.