### PR TITLE
docs(nixos): fix installation anchor

### DIFF
--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -17,8 +17,7 @@ Choose your installation method:
 
 **NixOS:**
 
-1. [Quick Run](#quick-run) - Test without installing
-2. [Permanent Installation](#permanent-installation) - Add to system configuration
+1. [Flake Installation](#flake-installation) - Add to system configuration using flakes
 
 **Any Distribution:**
 


### PR DESCRIPTION
Fixed the anchor for NixOS Flake Installation section.

- Updated anchor to `#flake-installation` 
- Verified the link works correctly and matches the section header

P.S. Anchors should stay in one place, unlike my 2 AM code! ⚓😴