### PR TITLE
Update keybinds for Control Center visibility toggle

### DIFF
--- a/src/content/docs/getting-started/keybinds.mdx
+++ b/src/content/docs/getting-started/keybinds.mdx
@@ -21,7 +21,7 @@ Noctalia provides extensive IPC (Inter-Process Communication) support, allowing 
 | Function | Command | Description |
 |----------|---------|-------------|
 | **Application Launcher** | `qs -c noctalia-shell ipc call launcher toggle` | Open/close the application launcher |
-| **Side Panel** | `qs -c noctalia-shell ipc call sidePanel toggle` | Toggle the side panel visibility |
+| **Control Center** | `qs -c noctalia-shell ipc call controlCenter toggle` | Toggle the control center visibility |
 | **Settings** | `qs -c noctalia-shell ipc call settings toggle` | Open/close the settings window |
 
 ### Quick Access


### PR DESCRIPTION
Replaced 'Side Panel' command with 'Control Center' command in keybinds documentation page.