### PR TITLE
docs: replace mentions of deprecated sidePanel with controlCenter

### DIFF
--- a/src/content/docs/getting-started/keybinds.mdx
+++ b/src/content/docs/getting-started/keybinds.mdx
@@ -108,7 +108,7 @@ Add these binds to your `~/.config/niri/config.kdl`:
 binds {
     // Core Noctalia binds
     Mod+Space { spawn "qs" "-c" "noctalia-shell" "ipc" "call" "launcher" "toggle"; }
-    Mod+S { spawn "qs" "-c" "noctalia-shell" "ipc" "call" "sidePanel" "toggle"; }
+    Mod+S { spawn "qs" "-c" "noctalia-shell" "ipc" "call" "controlCenter" "toggle"; }
     Mod+Comma { spawn "qs" "-c" "noctalia-shell" "ipc" "call" "settings" "toggle"; }
 
     // Audio controls
@@ -137,7 +137,7 @@ Add these binds to your `hyprland.conf`:
 ```bash
 # Core Noctalia binds
 bind = SUPER, SPACE, exec, qs -c noctalia-shell ipc call launcher toggle
-bind = SUPER, S, exec, qs -c noctalia-shell ipc call sidePanel toggle
+bind = SUPER, S, exec, qs -c noctalia-shell ipc call controlCenter toggle
 bind = SUPER, comma, exec, qs -c noctalia-shell ipc call settings toggle
 
 # Audio controls


### PR DESCRIPTION
This notification is shown when using `qs -s noctalia-shell ipc call sidePanel toggle`

<img width="425" height="123" alt="image" src="https://github.com/user-attachments/assets/2a27782c-431d-4e99-9049-5f780931e1c7" />
