### PR TITLE
docs: replace mentions of deprecated powerPanel with sessionMenu

### DIFF
--- a/src/content/docs/getting-started/nixos.mdx
+++ b/src/content/docs/getting-started/nixos.mdx
@@ -233,7 +233,7 @@ To safely configure noctalia keybindings in the Niri flake, be sure to pass a li
               "noctalia-shell" "ipc" "call" "launcher" "toggle" # ✅
             ];
             "Mod+P".action.spawn =
-              "noctalia-shell ipc call powerPanel toggle"; # ❌
+              "noctalia-shell ipc call sessionMenu toggle"; # ❌
         };
       };
     };


### PR DESCRIPTION
This notification is shown when using `qs -s noctalia-shell ipc call powerPanel toggle`

<img width="433" height="125" alt="image" src="https://github.com/user-attachments/assets/997cdf85-d0b4-4b90-9026-223e4120a737" />

