### PR TITLE
adding 2 optional transitive deps from quickshell - there may be more?

### DIFF
--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -229,6 +229,11 @@ mkdir -p ~/.config/quickshell/noctalia-shell && curl -sL https://github.com/noct
 
 - `ddcutil` - Desktop monitor brightness control (⚠️ may introduce system instability with certain monitors)
 - `power-profiles-daemon` - Enables power profile selection
+- `nmcli`, Network connection management[^1]
+- `upower`, Battery state[^1]
+- `bluez`, Bluetooth support[^1]
+
+[^1]:this dependency comes from quickshell
 
 **Optional but recommended:**
 
@@ -236,9 +241,6 @@ mkdir -p ~/.config/quickshell/noctalia-shell && curl -sL https://github.com/noct
 - `wlsunset` - Night light functionality
 - `xdg-desktop-portal` - Enables screen sharing and file picker functionality
 - `python3`, `evolution-data-server` - Calendar events
-- `nmcli`, Network connection management (from quickshell)
-- `upower`, Battery state (from quickshell)
-- `bluez`, Bluetooth support (from quickshell)
 
 :::tip
 Manual installation keeps Noctalia contained within your user directory, making it easy to remove without affecting system packages.

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -236,6 +236,8 @@ mkdir -p ~/.config/quickshell/noctalia-shell && curl -sL https://github.com/noct
 - `wlsunset` - Night light functionality
 - `xdg-desktop-portal` - Enables screen sharing and file picker functionality
 - `python3`, `evolution-data-server` - Calendar events
+- `nmcli`, Network connection management (from quickshell)
+- `upower`, Battery state (from quickshell)
 
 :::tip
 Manual installation keeps Noctalia contained within your user directory, making it easy to remove without affecting system packages.

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -238,6 +238,7 @@ mkdir -p ~/.config/quickshell/noctalia-shell && curl -sL https://github.com/noct
 - `python3`, `evolution-data-server` - Calendar events
 - `nmcli`, Network connection management (from quickshell)
 - `upower`, Battery state (from quickshell)
+- `bluez`, Bluetooth support (from quickshell)
 
 :::tip
 Manual installation keeps Noctalia contained within your user directory, making it easy to remove without affecting system packages.

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -229,9 +229,9 @@ mkdir -p ~/.config/quickshell/noctalia-shell && curl -sL https://github.com/noct
 
 - `ddcutil` - Desktop monitor brightness control (⚠️ may introduce system instability with certain monitors)
 - `power-profiles-daemon` - Enables power profile selection
-- `nmcli`, Network connection management[^1]
-- `upower`, Battery state[^1]
-- `bluez`, Bluetooth support[^1]
+- `nmcli` - Network connection management[^1]
+- `upower` - Battery state[^1]
+- `bluez` - Bluetooth support[^1]
 
 [^1]:this dependency comes from quickshell
 


### PR DESCRIPTION
as discussed on discord:
- there are cli dependencies which noctalia inherits from qs
- without these important functionality can't work,  and it is currently not super obvious what the right cli tools are,or what the complete list is, exspecially since there are often several possible cli tools for one job (eg `acpi -b` for battery instead of the required `upower`) 
- i have added 2 basic ones here, there may be more? 
- you may prefer a separate section for QS transititve deps

