### PR TITLE
Update optional dependencies in installation guide

### DIFF
--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -228,7 +228,7 @@ paru -S noctalia-qs brightnessctl git imagemagick python
 paru -S ddcutil
 
 # Optional dependencies
-paru -S cliphist cava wlsunset xdg-desktop-portal python3 evolution-data-server
+paru -S cliphist wlsunset xdg-desktop-portal python3 evolution-data-server
 
 ```
 


### PR DESCRIPTION
Removed 'cava' from the list of optional dependencies.