### PR TITLE
docs(v5): update panel-toggle launcher IPC with query parameter support

### DIFF
--- a/src/content/docs/v5/ipc/shell-and-ui.mdx
+++ b/src/content/docs/v5/ipc/shell-and-ui.mdx
@@ -31,7 +31,7 @@ These commands open, close, or toggle Noctalia UI surfaces.
 
 | Action | Command | Description |
 |--------|---------|-------------|
-| Toggle launcher | `noctalia msg panel-toggle launcher` | Open or close the app launcher. |
+| Toggle launcher | `noctalia msg panel-toggle launcher [query]` | Open or close the app launcher. Optional `query` pre-fills the search input (e.g. `noctalia msg panel-toggle launcher "/wall"`). |
 | Toggle session menu | `noctalia msg panel-toggle session` | Open or close the logout, reboot, and shutdown menu. |
 | Toggle clipboard | `noctalia msg panel-toggle clipboard` | Open or close clipboard history. |
 | Toggle wallpaper panel | `noctalia msg panel-toggle wallpaper` | Open or close wallpaper picker. |


### PR DESCRIPTION
This pull request updates the documentation for the `panel-toggle launcher` command to clarify its usage. The change makes it clear that an optional `query` argument can be provided to pre-fill the search input when opening the launcher.

Documentation update:

* Updated the description of the `noctalia msg panel-toggle launcher` command in `src/content/docs/v5/ipc/shell-and-ui.mdx` to mention the optional `query` argument, including an example of how to use it.