### PR TITLE
Update Fedora installation docs

### DIFF
--- a/src/content/docs/v4/getting-started/installation.mdx
+++ b/src/content/docs/v4/getting-started/installation.mdx
@@ -73,7 +73,7 @@ Read the post-install emerge messages for information on optional dependencies a
 
 ## Fedora {#fedora}
 
-Noctalia-shell is available in the [Terra](https://terra.fyralabs.com) repository.
+Noctalia-shell is available in the [Terra](https://terrapkg.com) repository.
 
 First install the repository as described on the website:
 

--- a/src/content/docs/v5/getting-started/installation.mdx
+++ b/src/content/docs/v5/getting-started/installation.mdx
@@ -60,7 +60,7 @@ sudo dnf copr enable lionheartp/Hyprland
 sudo dnf install noctalia-git
 ```
 
-Installing noctalia-shell from Terra will automatically install all runtime dependencies and display optional dependencies.
+Installing noctalia-git will automatically install all runtime dependencies and display optional dependencies.
 
 ---
 


### PR DESCRIPTION
Updates to the new Terra URL in v4 docs. Updates the package name and removes reference to Terra from v5 docs.