### PR TITLE
docs(v5): add info about opening control-center tabs

### DIFF
--- a/src/content/docs/v5/ipc/shell-and-ui.mdx
+++ b/src/content/docs/v5/ipc/shell-and-ui.mdx
@@ -37,7 +37,7 @@ These commands open, close, or toggle Noctalia UI surfaces.
 | Toggle session menu | <IpcCommand command="panel-toggle session" /> | Open or close the logout, reboot, and shutdown menu. |
 | Toggle clipboard | <IpcCommand command="panel-toggle clipboard" /> | Open or close clipboard history. |
 | Toggle wallpaper panel | <IpcCommand command="panel-toggle wallpaper" /> | Open or close wallpaper picker. |
-| Toggle control center | <IpcCommand command="panel-toggle control-center" /> | Open or close Control Center. |
+| Toggle control center | <IpcCommand command="panel-toggle control-center [tab]" /> | Open or close Control Center. Optional `tab` opens the tab inside control center by default (e.g. `noctalia msg panel-toggle control-center media` )  |
 
 ## Wallpaper
 


### PR DESCRIPTION
Adding information for opening different tabs in control-center by default. 