### PR TITLE
Ignore ACI for spell checking

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,5 @@
+[default.extend-words]
+ACI = "ACI"
 [files]
 extend-exclude = [
     # This file has a lot of non-English words that trigger false positives


### PR DESCRIPTION
Ignore `ACI` word in typo detection as it causes spelling workflow to always fail.