### PR TITLE
feat: enable GFM in astro configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -177,6 +177,7 @@ export default defineConfig({
     }),
   ],
   markdown: {
+    gfm: true,
     remarkPlugins: [remarkHeadingId],
   },
 });


### PR DESCRIPTION
I re-enabled GFM since it is required for proper support of elements like tables (`|---|---|`). Without it, the renderer was not recognizing them, causing several parts of the wiki to lose their formatting and render as plain text.

### GFM Enable
<img width="1829" height="989" alt="image" src="https://github.com/user-attachments/assets/9865bd80-5422-4a09-8078-d181e6bff704" />

### GFM Disable
<img width="1822" height="988" alt="image" src="https://github.com/user-attachments/assets/227061e4-1b81-4118-bf71-61845dd8d5a6" />
