### PR TITLE
gentoo: update guru package to gui-apps/noctalia, add v5 section

### DIFF
--- a/src/content/docs/v4/getting-started/installation.mdx
+++ b/src/content/docs/v4/getting-started/installation.mdx
@@ -46,7 +46,7 @@ The development version may be less stable than the official release. Use this v
 
 ## Gentoo {#gentoo}
 
-Noctalia-shell is available in the Gentoo [Guru](https://wiki.gentoo.org/wiki/Project:GURU) repository.
+Noctalia is available in the Gentoo [Guru](https://wiki.gentoo.org/wiki/Project:GURU) repository.
 
 First enable and sync the repository as described at [Guru Information for End Users](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users):
 
@@ -56,17 +56,17 @@ First enable and sync the repository as described at [Guru Information for End U
 ```
 
 
-Next, update the /etc/portage/package.accept_keywords file/folder to enable the unstable keyword on the noctalia-shell and gui-apps/noctalia-qs packages:
+Next, update the /etc/portage/package.accept_keywords file/folder to enable the unstable keyword on the gui-apps/noctalia and gui-apps/noctalia-qs packages:
 
 ```toml
-gui-apps/noctalia-shell ~amd64
+gui-apps/noctalia ~amd64
 gui-apps/noctalia-qs ~amd64
 ```
 
 Now the package can be installed through emerge:
 
 ```bash
-# emerge gui-apps/noctalia-shell
+# emerge gui-apps/noctalia
 ```
 
 Read the post-install emerge messages for information on optional dependencies and emerge them as well if desired.

--- a/src/content/docs/v5/getting-started/installation.mdx
+++ b/src/content/docs/v5/getting-started/installation.mdx
@@ -17,6 +17,7 @@ Noctalia is available on the following distributions:
 - [NixOS](/v5/getting-started/nixos/)
 - [Fedora](#fedora)
 - [openSUSE](#opensuse)
+- [Gentoo](#gentoo)
 - [Void Linux](#void)
 - [GNU Guix](#guix)
 - [AerynOS](#aeryn)
@@ -109,6 +110,34 @@ v5 will only be available for **Tumbleweed** and **Slowroll**. **Leap 16.0** is 
 - **[Stable version](https://build.opensuse.org/package/show/home:neifua:Noctalia/noctalia)**: Updated when a new release is tagged
 - **[Unstable version](https://build.opensuse.org/package/show/home:neifua:Noctalia/noctalia-git)**: Automatically rebuilt on OBS whenever a new commit is pushed
 :::
+
+---
+
+## Gentoo {#gentoo}
+
+Noctalia is available in the Gentoo [Guru](https://wiki.gentoo.org/wiki/Project:GURU) repository.
+
+First enable and sync the repository as described at [Guru Information for End Users](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users):
+
+```bash
+# eselect repository enable guru
+# emerge --sync guru
+```
+
+Next, update the /etc/portage/package.accept_keywords file/folder to enable the unstable keyword on the gui-apps/noctalia and gui-apps/noctalia-qs packages:
+
+```toml
+gui-apps/noctalia ~amd64
+gui-apps/noctalia-qs ~amd64
+```
+
+Now the package can be installed through emerge:
+
+```bash
+# emerge gui-apps/noctalia
+```
+
+Read the post-install emerge messages for information on optional dependencies and emerge them as well if desired.
 
 ---
 


### PR DESCRIPTION
The GURU `gui-apps/noctalia-shell` package was renamed to `gui-apps/noctalia` on 2026-06-08 (gentoo/guru commit be45a0d, following the upstream repo rename noctalia-dev/noctalia-shell → noctalia-dev/noctalia). The old atom no longer exists, and `gui-apps/noctalia` now ships both the v4.x (4.7.6 / 4.7.7) and v5 (5.0.0_pre / 9999) ebuilds, with `gui-apps/noctalia-qs` as the Quickshell-fork dependency.

- v4: point the existing Gentoo section at `gui-apps/noctalia`
- v5: add a Gentoo section (the v5 install page had none)

GURU rename commit: https://github.com/gentoo/guru/commit/be45a0d39cd99a790fad0a5eb5d21678dcea2b48
