### PR TITLE
fix(v4/getting-started/nixos): Configuration Defaults

### DIFF
--- a/src/components/SettingsReference.astro
+++ b/src/components/SettingsReference.astro
@@ -1,7 +1,7 @@
 ---
 import { Code } from '@astrojs/starlight/components';
 
-const URL = 'https://raw.githubusercontent.com/noctalia-dev/noctalia/main/Assets/settings-default.json';
+const URL = 'https://raw.githubusercontent.com/noctalia-dev/noctalia/legacy-v4/Assets/settings-default.json';
 
 let settingsJson = {};
 let errorMessage = '';


### PR DESCRIPTION
The `SettingsReference` component that is used in that section was failing to get the default settings from the `main` branch, so I've pointed it to the `legacy-v4` branch