### PR TITLE
docs(install): add missing fedora package

### DIFF
--- a/src/content/docs/v5/getting-started/installation.mdx
+++ b/src/content/docs/v5/getting-started/installation.mdx
@@ -324,7 +324,8 @@ If you prefer to install Noctalia locally or want more control over the installa
       cairo-devel pango-devel \
       libxkbcommon-devel glib2-devel \
       sdbus-cpp-devel pipewire-devel \
-      pam-devel polkit-devel libcurl-devel libwebp-devel librsvg2-devel libqalculate
+      pam-devel polkit-devel libcurl-devel libwebp-devel librsvg2-devel \
+      libqalculate-devel
     ```
   </TabItem>
   <TabItem label="Debian/Ubuntu">


### PR DESCRIPTION
Add `libqalculate-devel` to required Fedora packages in manual install.
Without it the installation fails on missing `libqalculate` dependency.