### PR TITLE
docs(install): Remove tinyexpr from vendored dependencies

### DIFF
--- a/src/content/docs/v5/getting-started/installation.mdx
+++ b/src/content/docs/v5/getting-started/installation.mdx
@@ -355,7 +355,7 @@ If you prefer to install Noctalia locally or want more control over the installa
   </TabItem>
 </Tabs>
 
-Vendored dependencies, with no system package needed: `Wuffs`, `nanosvg`, `tomlplusplus`, `tinyexpr`,
+Vendored dependencies, with no system package needed: `Wuffs`, `nanosvg`, `tomlplusplus`,
 `nlohmann/json`, `Luau`, `dr_wav`, `fzy`, `stb_image_resize2`, and Material Color Utilities.
 
 System packages required beyond the Wayland/GL stack: `libwebp` handles WebP decoding and thumbnail encoding. Wuffs


### PR DESCRIPTION
The math provider was switched libqalculate as a system dependency.

https://github.com/noctalia-dev/noctalia-docs/commit/4cd4ce62e67d2cb5e7d218090c9178d5d4585b28
https://github.com/noctalia-dev/noctalia/commit/83a2441e6e6091be9d0e701aa2cb32ac59300558