### PR TITLE
docs(weather): add description of "show_temperature" option in bar widget

### DIFF
--- a/src/content/docs/v5/bar/widgets.mdx
+++ b/src/content/docs/v5/bar/widgets.mdx
@@ -679,12 +679,14 @@ Shows the current weather in the bar and opens the Weather control-center tab on
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `max_length` | number | `160` | Maximum length for the weather text |
-| `show_condition` | bool | `true` | Show condition text like `Overcast` next to temperature |
+| `show_condition` | bool | `true` | Show condition text like `Overcast` next to temperature, or weather glyph |
+| `show_temperature` | bool | `true` | Show temperature text like `38°C` next to weather glyph |
 
 ```toml
 [widget.weather]
-max_length     = 180
-show_condition = false
+max_length       = 180
+show_condition   = false
+show_temperature = false
 ```
 
 ---


### PR DESCRIPTION
Add description of a new option for weather bar widget (toggle whether current temperature should be displayed) from: https://github.com/noctalia-dev/noctalia/pull/3201