### PR TITLE
chore: fix a typo

### DIFF
--- a/src/content/docs/v5/getting-started/nixos.mdx
+++ b/src/content/docs/v5/getting-started/nixos.mdx
@@ -323,6 +323,6 @@ To avoid this, the [`cachix`](https://github.com/noctalia-dev/noctalia/tree/cach
     ```
   </TabItem>
   <TabItem label="tarball">
-    Make sure not to update your tarball to a commit eariler than the latest commit on the cachix branch.
+    Make sure not to update your tarball to a commit earlier than the latest commit on the cachix branch.
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Just to prevent PR "typos" check from failing, like: https://github.com/noctalia-dev/noctalia-docs/actions/runs/28458499525/job/84339701194?pr=167