### PR TITLE
Update Void Linux installation docs

### DIFF
--- a/src/content/docs/v4/getting-started/installation.mdx
+++ b/src/content/docs/v4/getting-started/installation.mdx
@@ -177,21 +177,9 @@ Noctalia-shell is available through a custom XBPS repository.
 
 **Step 1**: Add the repository source
 
-<Tabs>
-  <TabItem label="GLibc">
-    ```bash
-	echo "repository=https://universalrepository.pages.dev/void" \
-  	| sudo tee /etc/xbps.d/10-noctalia.conf
-	```
-  </TabItem>
-  <TabItem label="Musl">
-    ```bash
-	echo "repository=https://universalrepository.pages.dev/void-musl" \
-  	| sudo tee /etc/xbps.d/10-noctalia.conf
-	```
-  </TabItem>
-</Tabs>
-
+```bash
+echo "repository=https://repo.voiders.dev" | sudo tee /etc/xbps.d/10-voiders-community.conf
+```
 
 **Step 2**: Sync and install noctalia-shell
 

--- a/src/content/docs/v5/getting-started/installation.mdx
+++ b/src/content/docs/v5/getting-started/installation.mdx
@@ -156,22 +156,11 @@ Noctalia is available through a custom XBPS repository.
 
 **Step 1**: Add the repository source
 
-<Tabs>
-  <TabItem label="GLibc">
-    ```bash
-	echo "repository=https://universalrepository.pages.dev/void" \
-  	| sudo tee /etc/xbps.d/10-noctalia.conf
-	```
-  </TabItem>
-  <TabItem label="Musl">
-    ```bash
-	echo "repository=https://universalrepository.pages.dev/void-musl" \
-  	| sudo tee /etc/xbps.d/10-noctalia.conf
-	```
-  </TabItem>
-</Tabs>
+```bash
+echo "repository=https://repo.voiders.dev" | sudo tee /etc/xbps.d/10-voiders-community.conf
+```
 
-**Step 2**: Sync and install noctalia
+**Step 2**: Sync and install Noctalia
 
 ```bash
 sudo xbps-install -S
@@ -179,7 +168,7 @@ sudo xbps-install noctalia
 ```
 
 :::note
-If your noctalia fails on run install sdbus from UniversalRepository because its up-to-update
+If Noctalia fails to run, install the `sdbus-c++` package.
 :::
 ---
 


### PR DESCRIPTION
Since Void Universalrepository is shutting down, i've made changes to reflect a new working community repository that contains `noctalia`, `noctalia-qs`, `noctlia-shell`, and `noctalia-greeter`.

The result of the build on the new repo's build server is available [here](https://git.voiders.dev/voiders-community/repository/actions/runs/158/jobs/0/attempt/1). It contains all of the mentioned packages despite only mentioning noctalia v4 in the title