### PR TITLE
docs: fix typo

### DIFF
--- a/src/content/docs/v5/templates/community/zenbrowser.mdx
+++ b/src/content/docs/v5/templates/community/zenbrowser.mdx
@@ -15,7 +15,7 @@ Zen Browser can load Noctalia's generated CSS through your profile's `userChrome
 
 2. **Set the Zen theme to Auto:**
   - Open **Settings → Appearance**
-  - Set **Website Appeararance** to **Auto** so Zen applies the colors from the Noctalia CSS
+  - Set **Website Appearance** to **Auto** so Zen applies the colors from the Noctalia CSS
 
 3. **Reload colors after changes:**
   - Restart Zen Browser to load the updated color scheme from Noctalia


### PR DESCRIPTION
I've spotted this typo when doing https://github.com/noctalia-dev/noctalia-docs/pull/174, but forgot to fix it in v5 as well.