### PR TITLE
docs: update hyprland syntax for window switcher and adjust hyprland keybinds

### DIFF
--- a/src/content/docs/v5/compositor-settings/hyprland.mdx
+++ b/src/content/docs/v5/compositor-settings/hyprland.mdx
@@ -71,19 +71,19 @@ hl.workspace_rule({ workspace = "5", monitor = "DP-1", persistent = true })
 Add these binds to your `hyprland.lua`:
 
 ```lua
-local ipc = "noctalia msg"
+local ipc = "noctalia msg "
 
 -- Core binds
-hl.bind(mainMod .. "+Space", hl.dsp.exec_cmd(ipc .. " panel-toggle launcher"))
-hl.bind(mainMod .. "+S", hl.dsp.exec_cmd(ipc .. " panel-toggle control-center"))
-hl.bind(mainMod .. "+comma", hl.dsp.exec_cmd(ipc .. " settings-toggle"))
+hl.bind(mainMod .. "+Space", hl.dsp.exec_cmd(ipc .. "panel-toggle launcher"))
+hl.bind(mainMod .. "+S", hl.dsp.exec_cmd(ipc .. "panel-toggle control-center"))
+hl.bind(mainMod .. "+comma", hl.dsp.exec_cmd(ipc .. "settings-toggle"))
 
 -- Media keys
-hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd(ipc .. " volume-up"))
-hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd(ipc .. " volume-down"))
-hl.bind("XF86AudioMute", hl.dsp.exec_cmd(ipc .. " volume-mute"))
-hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd(ipc .. " brightness-up"))
-hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd(ipc .. " brightness-down"))
+hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd(ipc .. "volume-up"))
+hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd(ipc .. "volume-down"))
+hl.bind("XF86AudioMute", hl.dsp.exec_cmd(ipc .. "volume-mute"))
+hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd(ipc .. "brightness-up"))
+hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd(ipc .. "brightness-down"))
 
 -- Noctalia Settings
 hl.window_rule({

--- a/src/content/docs/v5/ipc/shell.mdx
+++ b/src/content/docs/v5/ipc/shell.mdx
@@ -35,7 +35,7 @@ Alt+Tab-style overlay: a dimmed fullscreen layer with a centered grid of open wi
 Example Hyprland bind:
 
 ```ini
-bind = ALT, Tab, exec, noctalia msg window-switcher
+hl.bind("ALT + Tab", hl.dsp.exec_cmd("noctalia msg window-switcher"))
 ```
 
 While the overlay is open it takes exclusive keyboard focus on its layer surface:


### PR DESCRIPTION
windows switcher keybind example was still on old hyprlang syntax and i adjusted the ipc keybinds to be cleaner for new binds