### PR TITLE
docs(greeter): document [output] width/height mode override

### DIFF
--- a/src/content/docs/v5/greeter/configuration.mdx
+++ b/src/content/docs/v5/greeter/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: greeter.toml settings for sessions, color scheme, monitors, UI scale, cursor theme, and keyboard layout.
+description: greeter.toml settings for sessions, color scheme, monitors, output mode, UI scale, cursor theme, and keyboard layout.
 sidebar:
   order: 1
 ---
@@ -12,6 +12,7 @@ If the file is missing, the greeter uses built-in defaults (auto UI scale, all m
 - [Keys the greeter remembers](#keys-the-greeter-remembers)
 - [Admin-only keys](#admin-only-keys)
 - [Multi-monitor](#multi-monitor)
+- [Output mode](#output-mode)
 - [UI scale](#ui-scale)
 - [Cursor theme](#cursor-theme)
 - [Keyboard layout](#keyboard-layout)
@@ -42,6 +43,8 @@ Set these yourself. The greeter UI does not change them.
 | `[user].default` | Username to select on startup. Opens the password step immediately. `--user` on the greetd command line wins. Press **Esc** or **Back** to pick another user. |
 | `[output].name` | Wayland connector name to show the greeter on (see [Multi-monitor](#multi-monitor)) |
 | `[output].layout` | Multi-monitor positions as `NAME:X,Y; ...` in logical pixels (see [Multi-monitor](#multi-monitor)) |
+| `[output].width` | Preferred DRM mode width in pixels (see [Output mode](#output-mode)) |
+| `[output].height` | Preferred DRM mode height in pixels (see [Output mode](#output-mode)) |
 | `[output].scale` | Manual UI scale factor (see [UI scale](#ui-scale)) |
 | `[cursor].theme` | Cursor theme name (e.g. `Adwaita`); missing → wlroots default cursor (see [Cursor theme](#cursor-theme)) |
 | `[cursor].size` | Cursor size in pixels (e.g. `24`); missing → `24` |
@@ -72,6 +75,8 @@ hide_logo = false
 [output]
 name = "DP-2"
 layout = "DP-1:0,0; DP-2:2560,0"
+width = 5120
+height = 2160
 scale = 1.5
 
 [cursor]
@@ -123,11 +128,36 @@ List connector names from a running Wayland session:
 noctalia-greeter outputs
 ```
 
-Restart greetd after changing `[output].name`:
+Restart greetd after changing `[output].name` or `[output].width` / `[output].height`:
 
 ```sh
 sudo systemctl restart greetd
 ```
+
+---
+
+## Output mode
+
+By default the greeter compositor modesets each connector to the EDID preferred mode (highest refresh at that size). On some setups that preferred mode differs from your desktop session resolution, so login flashes or modesets when the session starts.
+
+To pin the greeter to a specific resolution, set both `[output].width` and `[output].height`:
+
+```toml
+[output]
+name = "DP-2"
+width = 5120
+height = 2160
+```
+
+When both values are set, the compositor picks the **highest-refresh DRM mode** that matches that size. If no mode of that size is advertised, it logs a warning and falls back to the preferred mode.
+
+Both keys are required. If only one is set, the greeter ignores the partial override and uses preferred mode. Invalid (non-positive) values are also ignored.
+
+:::note
+`[output].width` / `[output].height` control the **physical DRM mode** (pixels). They are separate from `[output].scale`, which only affects greeter UI scaling.
+:::
+
+Match these values to the mode your desktop session uses if you want a seamless greeter → session transition.
 
 ---
 

--- a/src/content/docs/v5/greeter/configuration.mdx
+++ b/src/content/docs/v5/greeter/configuration.mdx
@@ -138,7 +138,7 @@ sudo systemctl restart greetd
 
 ## Output mode
 
-By default the greeter compositor modesets each connector to the EDID preferred mode (highest refresh at that size). On some setups that preferred mode differs from your desktop session resolution, so login flashes or modesets when the session starts.
+By default the greeter compositor modesets each connector using the EDID preferred resolution, then the **highest refresh rate** available at that size. On some setups that mode differs from your desktop session (resolution and/or refresh), so login flashes or modesets when the session starts.
 
 To pin the greeter to a specific resolution, set both `[output].width` and `[output].height`:
 
@@ -149,9 +149,9 @@ width = 5120
 height = 2160
 ```
 
-When both values are set, the compositor picks the **highest-refresh DRM mode** that matches that size. If no mode of that size is advertised, it logs a warning and falls back to the preferred mode.
+When both values are set, the compositor uses that size and still picks the **highest-refresh** advertised mode for it. If no mode of that size is advertised, it logs a warning and falls back to the preferred-resolution path above.
 
-Both keys are required. If only one is set, the greeter ignores the partial override and uses preferred mode. Invalid (non-positive) values are also ignored.
+Both keys are required. If only one is set, the greeter ignores the partial override and uses the preferred-resolution path. Invalid (non-positive) values are also ignored.
 
 :::note
 `[output].width` / `[output].height` control the **physical DRM mode** (pixels). They are separate from `[output].scale`, which only affects greeter UI scaling.

--- a/src/content/docs/v5/greeter/index.mdx
+++ b/src/content/docs/v5/greeter/index.mdx
@@ -120,7 +120,7 @@ After syncing, log out or restart greetd to see the changes on the login screen.
 
 The greeter adds a **Synced** color scheme when sync data is present. Session and scheme choices you make on the login screen are remembered in `/var/lib/noctalia-greeter/greeter.toml`.
 
-For monitor selection, UI scale, cursor theme, and other admin settings, see [Configuration](/v5/greeter/configuration/).
+For monitor selection, output mode, UI scale, cursor theme, and other admin settings, see [Configuration](/v5/greeter/configuration/).
 
 ---
 
@@ -153,5 +153,6 @@ The greeter works without a mouse.
 - **Sync fails with no privilege escalator** - Greeter sync needs `pkexec` or `run0` on `PATH` (for example when `pkexec` is disabled on NixOS, install `run0` from systemd ≥ 256). A polkit authentication agent must be running in your session.
 - **Sync Now does nothing / no `appearance.json`** - Sync stages files first, then waits for polkit to authorize `noctalia-greeter-apply-appearance`. On **seatd without logind**, Noctalia's polkit agent cannot register; run the `pkexec` command from the Sync Now notification in a terminal. Sync Now warns after 90 seconds if approval is still pending.
 - **Polkit agent: `No session for pid`** - Expected on seatd-only setups. Install elogind for in-session prompts, or use terminal/console `pkexec` for greeter sync.
+- **Blank flash or modeset at login** - The greeter may be using a different DRM mode than your desktop session. Set matching `[output].width` and `[output].height` in `greeter.toml`. See [Output mode](/v5/greeter/configuration/#output-mode).
 - **UI too small or too large on a high-DPI monitor** - Set `[output].scale` in `greeter.toml`. See [Configuration](/v5/greeter/configuration/#ui-scale).
 - **Wrong or default cursor theme** - Set `[cursor].theme` (and `[cursor].size`) in `greeter.toml`, or the `XCURSOR_*` variables in the greetd command. If the theme is not on the default search path, also set `[cursor].path` / `XCURSOR_PATH`. See [Cursor theme](/v5/greeter/configuration/#cursor-theme).


### PR DESCRIPTION
## Summary

Documents the optional `[output].width` / `[output].height` keys from [noctalia-greeter#55](https://github.com/noctalia-dev/noctalia-greeter/pull/55):

- Add keys to the admin-only reference table and example `greeter.toml`
- New **Output mode** section: highest-refresh matching mode, both keys required, fallback to preferred mode
- Clarify that mode size is separate from `[output].scale`
- Greeter index troubleshooting for blank/modeset flash at login

## Context

Requested on [noctalia-greeter#55](https://github.com/noctalia-dev/noctalia-greeter/pull/55#issuecomment-4958093262) by @Ly-sec.

## Test plan

- [ ] Preview docs site and check `/v5/greeter/configuration/#output-mode` renders
- [ ] Confirm TOC and troubleshooting links resolve