### PR TITLE
docs(greeter): document [idle] timeout blanking

### DIFF
--- a/src/content/docs/v5/greeter/configuration.mdx
+++ b/src/content/docs/v5/greeter/configuration.mdx
@@ -179,10 +179,11 @@ timeout = 300
 
 While blanked, the greeter client stays running. Any **key press**, **mouse button press**, or **touch** wakes the displays and restarts the idle timer. Pointer motion and scroll only wake a blanked screen — they do not reset the timer while the screen is on (wireless mice often emit motion noise that would otherwise prevent blanking).
 
-Optional environment override (wins when set), useful because greetd starts greeters with an empty environment:
+Optional environment override (wins when set), useful because greetd starts greeters with an empty environment. Put it on the greetd session **command** (not only as a bare shell assignment):
 
-```sh
-NOCTALIA_GREETER_IDLE_TIMEOUT=300
+```toml
+[default_session]
+command = "env NOCTALIA_GREETER_IDLE_TIMEOUT=300 /usr/bin/noctalia-greeter-session"
 ```
 
 On NixOS you can set the same value through the module:

--- a/src/content/docs/v5/greeter/configuration.mdx
+++ b/src/content/docs/v5/greeter/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: greeter.toml settings for sessions, color scheme, monitors, output mode, UI scale, cursor theme, and keyboard layout.
+description: greeter.toml settings for sessions, color scheme, monitors, output mode, idle blanking, UI scale, cursor theme, and keyboard layout.
 sidebar:
   order: 1
 ---
@@ -13,6 +13,7 @@ If the file is missing, the greeter uses built-in defaults (auto UI scale, all m
 - [Admin-only keys](#admin-only-keys)
 - [Multi-monitor](#multi-monitor)
 - [Output mode](#output-mode)
+- [Idle blanking](#idle-blanking)
 - [UI scale](#ui-scale)
 - [Cursor theme](#cursor-theme)
 - [Keyboard layout](#keyboard-layout)
@@ -46,6 +47,7 @@ Set these yourself. The greeter UI does not change them.
 | `[output].width` | Preferred DRM mode width in pixels (see [Output mode](#output-mode)) |
 | `[output].height` | Preferred DRM mode height in pixels (see [Output mode](#output-mode)) |
 | `[output].scale` | Manual UI scale factor (see [UI scale](#ui-scale)) |
+| `[idle].timeout` | Seconds with no input before blanking outputs; `0` disables (see [Idle blanking](#idle-blanking)) |
 | `[cursor].theme` | Cursor theme name (e.g. `Adwaita`); missing → wlroots default cursor (see [Cursor theme](#cursor-theme)) |
 | `[cursor].size` | Cursor size in pixels (e.g. `24`); missing → `24` |
 | `[cursor].path` | Colon-separated theme search path (sets `XCURSOR_PATH`); needed when the theme is not on the default search path (`~/.icons:/usr/share/icons:/usr/share/pixmaps`) |
@@ -78,6 +80,9 @@ layout = "DP-1:0,0; DP-2:2560,0"
 width = 5120
 height = 2160
 scale = 1.5
+
+[idle]
+timeout = 300
 
 [cursor]
 theme = "Adwaita"
@@ -158,6 +163,39 @@ Both keys are required. If only one is set, the greeter ignores the partial over
 :::
 
 Match these values to the mode your desktop session uses if you want a seamless greeter → session transition.
+
+---
+
+## Idle blanking
+
+By default the greeter never blanks the screen. To turn off active DRM outputs after a period with no input, set `[idle].timeout` in seconds:
+
+```toml
+[idle]
+timeout = 300
+```
+
+`0` or omitting the key disables blanking. Valid values are `0`–`86400` (24 hours).
+
+While blanked, the greeter client stays running. Any **key press**, **mouse button press**, or **touch** wakes the displays and restarts the idle timer. Pointer motion and scroll only wake a blanked screen — they do not reset the timer while the screen is on (wireless mice often emit motion noise that would otherwise prevent blanking).
+
+Optional environment override (wins when set), useful because greetd starts greeters with an empty environment:
+
+```sh
+NOCTALIA_GREETER_IDLE_TIMEOUT=300
+```
+
+On NixOS you can set the same value through the module:
+
+```nix
+programs.noctalia-greeter.settings.idle.timeout = 300;
+```
+
+Restart greetd after changing the timeout:
+
+```sh
+sudo systemctl restart greetd
+```
 
 ---
 

--- a/src/content/docs/v5/greeter/index.mdx
+++ b/src/content/docs/v5/greeter/index.mdx
@@ -120,7 +120,7 @@ After syncing, log out or restart greetd to see the changes on the login screen.
 
 The greeter adds a **Synced** color scheme when sync data is present. Session and scheme choices you make on the login screen are remembered in `/var/lib/noctalia-greeter/greeter.toml`.
 
-For monitor selection, output mode, UI scale, cursor theme, and other admin settings, see [Configuration](/v5/greeter/configuration/).
+For monitor selection, output mode, idle blanking, UI scale, cursor theme, and other admin settings, see [Configuration](/v5/greeter/configuration/).
 
 ---
 
@@ -154,5 +154,7 @@ The greeter works without a mouse.
 - **Sync Now does nothing / no `appearance.json`** - Sync stages files first, then waits for polkit to authorize `noctalia-greeter-apply-appearance`. On **seatd without logind**, Noctalia's polkit agent cannot register; run the `pkexec` command from the Sync Now notification in a terminal. Sync Now warns after 90 seconds if approval is still pending.
 - **Polkit agent: `No session for pid`** - Expected on seatd-only setups. Install elogind for in-session prompts, or use terminal/console `pkexec` for greeter sync.
 - **Blank flash or modeset at login** - The greeter may be using a different DRM mode than your desktop session. Set matching `[output].width` and `[output].height` in `greeter.toml`. See [Output mode](/v5/greeter/configuration/#output-mode).
+- **Screen never blanks on the greeter** - Set `[idle].timeout` (seconds) in `greeter.toml`. Pointer motion alone does not count as activity. See [Idle blanking](/v5/greeter/configuration/#idle-blanking).
+- **Blanked greeter will not wake** - Use a key press, mouse button, or touch. If outputs stay off, check greeter compositor logs for idle/output commit errors.
 - **UI too small or too large on a high-DPI monitor** - Set `[output].scale` in `greeter.toml`. See [Configuration](/v5/greeter/configuration/#ui-scale).
 - **Wrong or default cursor theme** - Set `[cursor].theme` (and `[cursor].size`) in `greeter.toml`, or the `XCURSOR_*` variables in the greetd command. If the theme is not on the default search path, also set `[cursor].path` / `XCURSOR_PATH`. See [Cursor theme](/v5/greeter/configuration/#cursor-theme).


### PR DESCRIPTION
## Summary

Documents the optional `[idle].timeout` key from [noctalia-greeter#56](https://github.com/noctalia-dev/noctalia-greeter/pull/56):

- Admin-only key table + example `greeter.toml`
- New **Idle blanking** section: timeout range, wake vs activity rules, `NOCTALIA_GREETER_IDLE_TIMEOUT` override, NixOS settings
- Greeter index troubleshooting for never-blanks / never-wakes

## Context

Paired with the idle blanking greeter PR.

## Test plan

- [ ] Preview `/v5/greeter/configuration/#idle-blanking`
- [ ] Confirm TOC and troubleshooting links resolve