### PR TITLE
docs: add build from source for Void Linux

### DIFF
--- a/src/content/docs/v4/getting-started/installation.mdx
+++ b/src/content/docs/v4/getting-started/installation.mdx
@@ -197,6 +197,29 @@ sudo xbps-remove quickshell
 ```
 :::
 
+### Alternative: Build from source using xbps-src
+
+```
+# Install git, wget
+sudo xbps-install git wget
+
+# Set up the Void packages tree
+git clone --depth 1 https://github.com/void-linux/void-packages.git
+cd void-packages
+./xbps-src binary-bootstrap
+
+# Copy Noctalia build templates
+mkdir srcpkgs/noctalia-shell srcpkgs/noctalia-qs
+wget https://git.voiders.dev/voiders-community/repository/raw/branch/main/pkgs/noctalia-shell/template -P srcpkgs/noctalia-shell/
+wget https://git.voiders.dev/voiders-community/repository/raw/branch/main/pkgs/noctalia-qs/template -P srcpkgs/noctalia-qs/
+
+# Build the packages
+./xbps-src pkg noctalia-shell
+
+# Install the built packages
+sudo xbps-install --repository=hostdir/binpkgs noctalia-shell
+```
+
 ---
 
 ## Manual Installation {#manual-install}


### PR DESCRIPTION
Currently the Noctalia web site Getting Started / Installation section contains instructions for multiple Linux distributions, including Void Linux, with the suggestion to add a custom XBPS repository. Although binary packages from a third party are a convenient method of delivery, not everyone is keen on following that installation path due to trust, security and various other reasons. In addition to the existing documentation I propose adding alternative instructions on how to build Noctalia from a template which is a prominent feature of Void Linux.