### PR TITLE
docs: add build from source (v5) for Void Linux

### DIFF
--- a/src/content/docs/v5/getting-started/installation.mdx
+++ b/src/content/docs/v5/getting-started/installation.mdx
@@ -176,6 +176,29 @@ sudo xbps-install noctalia
 :::note
 If Noctalia fails to run, install the `sdbus-c++` package.
 :::
+
+### Alternative: Build from source using xbps-src
+
+```
+# Install git, wget
+sudo xbps-install git wget
+
+# Set up the Void packages tree
+git clone --depth 1 https://github.com/void-linux/void-packages.git
+cd void-packages
+./xbps-src binary-bootstrap
+
+# Copy Noctalia build templates
+mkdir srcpkgs/noctalia
+wget https://git.voiders.dev/voiders-community/repository/raw/branch/main/pkgs/noctalia/template -P srcpkgs/noctalia/
+
+# Build the packages
+./xbps-src pkg noctalia
+
+# Install the built packages
+sudo xbps-install --repository=hostdir/binpkgs noctalia
+```
+
 ---
 
 ## GNU Guix {#guix}


### PR DESCRIPTION
Currently the Noctalia web site Getting Started / Installation section contains instructions for multiple Linux distributions, including Void Linux, with the suggestion to add a custom XBPS repository. Although binary packages from a third party are a convenient method of delivery, not everyone is keen on following that installation path due to trust, security and various other reasons. In addition to the existing documentation I propose adding alternative instructions on how to build Noctalia (v5) from a template which is a prominent feature of Void Linux.