### PR TITLE
docs(window-switcher): document bind and blur settings for Niri and Hyprland

### DIFF
--- a/src/content/docs/v5/compositor-settings/hyprland.mdx
+++ b/src/content/docs/v5/compositor-settings/hyprland.mdx
@@ -77,6 +77,7 @@ local ipc = "noctalia msg "
 hl.bind(mainMod .. "+Space", hl.dsp.exec_cmd(ipc .. "panel-toggle launcher"))
 hl.bind(mainMod .. "+S", hl.dsp.exec_cmd(ipc .. "panel-toggle control-center"))
 hl.bind(mainMod .. "+comma", hl.dsp.exec_cmd(ipc .. "settings-toggle"))
+hl.bind("ALT + Tab", hl.dsp.exec_cmd(ipc .. "window-switcher"))
 
 -- Media keys
 hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd(ipc .. "volume-up"))
@@ -104,7 +105,7 @@ We also disable Hyprland's built-in layer animations for Noctalia so they do not
 hl.layer_rule({
   name = "noctalia",
   match = {
-    namespace = "^noctalia-(bar-.+|notification|dock|panel|attached-panel|osd)$",
+    namespace = "^noctalia-(bar-.+|notification|dock|panel|attached-panel|osd|window-switcher)$",
   },
   no_anim = true,
   ignore_alpha = 0.5,

--- a/src/content/docs/v5/compositor-settings/niri.mdx
+++ b/src/content/docs/v5/compositor-settings/niri.mdx
@@ -57,6 +57,8 @@ binds {
     Mod+Space { spawn-sh "noctalia msg panel-toggle launcher"; }
     Mod+S { spawn-sh "noctalia msg panel-toggle control-center"; }
     Mod+Comma { spawn-sh "noctalia msg settings-toggle"; }
+    Alt+Tab { spawn-sh "noctalia msg window-switcher"; }
+    // Niri has a built-in window switcher you might want to try it to see which one you prefer.
 
     // Audio & Brightness
     XF86AudioRaiseVolume { spawn-sh "noctalia msg volume-up"; }
@@ -178,6 +180,15 @@ layer-rule {
     xray false
     // blur false
   }
+}
+
+/* Enable blur on noctalia's window switcher and disable xray. */
+layer-rule {
+    match namespace="noctalia-window-switcher"
+    background-effect {
+        blur true
+        xray false
+    }
 }
 
 /* You can also fine-tune the blur effect globally. */


### PR DESCRIPTION
On Niri, it's a different layer rule because it's not enabled by default.