### PR TITLE
docs(installation): add missing noctalia-qs src build for Void Linux

### DIFF
--- a/src/content/docs/v4/getting-started/installation.mdx
+++ b/src/content/docs/v4/getting-started/installation.mdx
@@ -221,9 +221,10 @@ wget https://git.voiders.dev/voiders-community/repository/raw/branch/main/pkgs/n
 
 # Build the packages
 ./xbps-src pkg noctalia-shell
+./xbps-src pkg noctalia-qs
 
 # Install the built packages
-sudo xbps-install --repository=hostdir/binpkgs noctalia-shell
+sudo xbps-install -R hostdir/binpkgs noctalia-shell
 ```
 
 ---


### PR DESCRIPTION
Make sure to also build noctalia-qs from template (will be installed as dependency of noctalia-shell but must be built first and exist in local repo).

Use short switch in xbps-install for simpler/cleaner looks.