### PR TITLE
docs(session): document `show_shortcuts` for the session panel

### DIFF
--- a/src/content/docs/v5/configuration/shell.mdx
+++ b/src/content/docs/v5/configuration/shell.mdx
@@ -407,6 +407,7 @@ Panel-level settings under `[shell.session]`:
 |-------|------|---------|-------------|
 | `grid` | bool | `false` | When `true`, lays the session actions out over multiple rows of `grid_columns` instead of fitting them on a single row. |
 | `grid_columns` | number | `3` | Actions per row when `grid` is `true` (1-5). Ignored when `grid` is `false`. |
+| `show_shortcuts` | bool | `true` | When `true`, shows the keyboard shortcut for each session action at the top right corner. |
 
 Each entry in the `[[shell.session.actions]]` array takes:
 


### PR DESCRIPTION
Documentation for https://github.com/noctalia-dev/noctalia/pull/3567