### PR TITLE
Docs/history retention hours

### DIFF
--- a/src/content/docs/v5/services/notifications.mdx
+++ b/src/content/docs/v5/services/notifications.mdx
@@ -19,6 +19,7 @@ offset_x                 = 20          # absolute horizontal margin from the scr
 offset_y                 = 8           # absolute vertical margin from the screen edge
 monitors                 = []          # empty = all monitors; otherwise connector/description selectors (e.g. ["eDP-1", "DP-1"])
 collapse_on_dismiss      = true        # slide remaining toasts to close gaps when one is dismissed
+history_retention_hours  = 0     # auto-remove history entries older than N hours; 0 = keep forever
 
 [notification.filter.rhythmbox]
 enabled         = true
@@ -42,6 +43,7 @@ play_sound      = true
 - Internal Noctalia notifications are transient toasts and are not stored in notification history.
 - `collapse_on_dismiss = true` (default) causes remaining toasts to slide into a compact stack when one is dismissed. Set to `false` for stable-slot behavior where toasts keep their original positions.
 - `border = true` (default) draws an outline around toast cards. Set to `false` for a borderless look.
+- `history_retention_hours = 0` (default) keeps notification history entries forever. Set to a positive integer (1–8760) to automatically remove entries older than that many hours from control-center history. Active on-screen toasts are never removed. Configure in **Settings → Notifications → History**.
 
 ## Filtering
 

--- a/src/content/docs/v5/services/notifications.mdx
+++ b/src/content/docs/v5/services/notifications.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ```toml
 [notification]
-enable_daemon          = true        # when false, don't claim org.freedesktop.Notifications; internal toasts still work
+enable_daemon            = true        # when false, don't claim org.freedesktop.Notifications; internal toasts still work
 show_app_name            = true        # show the sending application name in toasts
 show_actions             = true        # show action buttons; when false, clicking a toast triggers its default action
 position                 = "top_right" # top_right | top_left | top_center | bottom_right | bottom_left | bottom_center
@@ -19,7 +19,7 @@ offset_x                 = 20          # absolute horizontal margin from the scr
 offset_y                 = 8           # absolute vertical margin from the screen edge
 monitors                 = []          # empty = all monitors; otherwise connector/description selectors (e.g. ["eDP-1", "DP-1"])
 collapse_on_dismiss      = true        # slide remaining toasts to close gaps when one is dismissed
-history_retention_hours  = 0     # auto-remove history entries older than N hours; 0 = keep forever
+history_retention_hours  = 0           # auto-remove history entries older than N hours; 0 = keep forever
 
 [notification.filter.rhythmbox]
 enabled         = true


### PR DESCRIPTION
## Summary

Add `history_retention_hours` to the notification config reference.

## Changes

- Added `history_retention_hours` key to the TOML config block
- Added bullet point explaining its behavior, range, and Settings path

## Related

Follow-up to noctalia-dev/noctalia#3653, implements the docs side of closing noctalia-dev/noctalia#3514. 