### PR TITLE
Update labwc.mdx with multiple monitor support for wlopm

### DIFF
--- a/src/content/docs/v5/compositor-settings/labwc.mdx
+++ b/src/content/docs/v5/compositor-settings/labwc.mdx
@@ -64,4 +64,7 @@ Create a custom command for dpms on and off using wlopm. Add the below commands 
 timeout = 600
 command = "wlopm --off [Monitor name]"
 resume_command = "wlopm --on [Monitor name]"
+# for multiple monitors
+# command = "wlopm --off [Monitor name0]; wlopm --off [Monitor name1]; wlopm --off [Monitor name2]"
+# resume_command = "wlopm --on [Monitor name0]; wlopm --on [Monitor name1]; wlopm --on [Monitor name2]"
 ```


### PR DESCRIPTION
Just adds an example as comments in the markdown code block.

This is in my `[idle.behavior.screen-off]` to demonstrate a working solution.

```toml
timeout = 720
command = "wlopm --off HDMI-A-1; wlopm --off HDMI-A-2"       # turns monitors off, and back on when you return
resume_command = "wlopm --on HDMI-A-1; wlopm --on HDMI-A-2"
```