### PR TITLE
docs(shell): keybinds copy/save

### DIFF
--- a/src/content/docs/v5/configuration/shell.mdx
+++ b/src/content/docs/v5/configuration/shell.mdx
@@ -411,6 +411,8 @@ up       = ["up"]
 down     = ["down"]
 tab_next = ["tab"]
 tab_previous = ["shift+tab", "iso_left_tab"]
+copy     = ["ctrl+c"]
+save     = ["ctrl+s"]
 delete   = ["del"]
 ```
 
@@ -422,7 +424,7 @@ Each action accepts a single string chord or an array of chords.
 
 **`super` bindings are rejected** (`super`, `win`, `windows`, `logo`, `meta`, `mod4`) and produce a config parse error.
 
-**Supported actions:** `validate`, `cancel`, `left`, `right`, `up`, `down`, `tab_next`, `tab_previous`, `delete`
+**Supported actions:** `validate`, `cancel`, `left`, `right`, `up`, `down`, `tab_next`, `tab_previous`, `copy`, `save`, `delete`
 
 | Action | Default role |
 |--------|----------------|
@@ -430,6 +432,8 @@ Each action accepts a single string chord or an array of chords.
 | `cancel` | Close a popup/panel or dismiss the current operation. |
 | `left` / `right` / `up` / `down` | Move within the focused region (list rows, launcher grid columns, slider nudge on left/right, and similar). |
 | `tab_next` / `tab_previous` | Move between major panes in split layouts (for example Settings sidebar ↔ content, or Control Center sidebar ↔ tab body). |
+| `copy` | Copy the selected region or item to the clipboard (for example, forcing a screenshot region to copy). |
+| `save` | Save the selected region or item to a file (for example, forcing a screenshot region to save). |
 | `delete` | Delete the selected item after confirmation (for example, a clipboard history entry). |
 
 On split-pane surfaces (**Settings** and **Control Center**), `tab_next` / `tab_previous` switch between the sidebar and the main content area. Arrow keys stay inside the active pane: the sidebar uses roving focus, and the content area moves between controls on up/down while leaving left/right to control-native behavior (such as slider nudge). The session panel uses arrow keys to move between actions once focus has entered the button list; it does not pre-select an action on open.


### PR DESCRIPTION
update docs with new copy and save shell keybinds (noctalia-dev/noctalia#3538).