### PR TITLE
docs(bluetooth-codec): Add documentation for Bluetooth codec selection in the Control Center audio panel

### DIFF
--- a/src/content/docs/noctalia/control-center/index.mdx
+++ b/src/content/docs/noctalia/control-center/index.mdx
@@ -90,6 +90,8 @@ The Media tab shows active MPRIS players and exposes playback controls independe
 
 The Audio tab groups PipeWire output, input, device, and stream controls. Use it for volume changes, muting, selecting devices, and inspecting application streams without opening an external mixer.
 
+When the active output is a Bluetooth device offering more than one codec, the Output card also shows a **Codec** drop-down. See [Bluetooth codecs](/noctalia/services/audio/#bluetooth-codecs).
+
 ## Monitor
 
 The Monitor tab exposes brightness controls when Noctalia has a controllable backlight for the display. If no writable brightness device is available, the tab remains available but has no write controls to expose.

--- a/src/content/docs/noctalia/services/audio.mdx
+++ b/src/content/docs/noctalia/services/audio.mdx
@@ -21,6 +21,27 @@ notification_sound   = ""     # empty = bundled default sounds/notification.wav
   Files are decoded through `libsndfile`; common supported formats include WAV, FLAC, Ogg/Vorbis, Opus, MP3, and AIFF.
   Exact format support depends on the distribution's libsndfile build.
 
+## Bluetooth codecs
+
+When the active output is a Bluetooth device, the Output card in Control Center → Audio shows a **Codec** drop-down for switching the codec the device is using. The change applies immediately, and WirePlumber remembers it, so the device reconnects on the same codec.
+
+The row appears only when the active output offers two or more codec choices. Wired and USB devices do not show it.
+
+| Codec | What it is |
+|-------|------------|
+| `SBC` | The baseline A2DP codec that every Bluetooth audio device supports. Always available, lowest quality of the A2DP options. |
+| `SBC-XQ` | SBC run at a higher bitrate. Better quality than plain SBC on devices that hold the connection well. |
+| `AAC` | Generally better than SBC at the same bitrate, though the result depends on how well the device decodes it. Common on Apple hardware. |
+| `aptX` / `aptX HD` | Qualcomm codecs. Plain `aptX` favors low latency, `aptX HD` a higher bitrate. Both ends have to support them. |
+| `LDAC` | Sony's high-bitrate codec, the highest-quality option when it is available. Drops to lower bitrates when the signal is weak. |
+| `HFP` | Headset mode. The only option that enables the microphone, at much lower playback quality. |
+
+Which entries appear depends on the headset and on what your PipeWire and WirePlumber build supports. `aptX` and `LDAC` in particular need optional libraries that not every distribution ships. The active codec is marked with a checkmark.
+
+Higher-quality codecs use more bandwidth and battery. `HFP` stands in for every handsfree variant the device reports (CVSD, mSBC, LC3-SWB), and Noctalia picks the best one available; headsets often switch to it on their own during a call and stay there afterward, which is when this drop-down is most useful.
+
+Selecting a virtual sink such as an EasyEffects sink as the output device hides the row, because no Bluetooth device sits directly behind that sink.
+
 ## Related IPC
 
 For output and microphone commands, default steps, mute behavior, and overdrive limits, see:


### PR DESCRIPTION
Related to https://github.com/noctalia-dev/noctalia/pull/3863