### PR TITLE
fix: broken links in umbriel docs

### DIFF
--- a/src/content/docs/umbriel/configuration.mdx
+++ b/src/content/docs/umbriel/configuration.mdx
@@ -84,9 +84,9 @@ back_and_forth = true
 | ---------------- | ---- | ------- | ----------------------------------------------------------------------------------------------- |
 | `back_and_forth` | bool | `false` | Re-selecting the active workspace jumps back to the previously active workspace on that output. |
 
-Output workspaces are dynamic by default. See [Outputs](outputs.md) for dynamic
+Output workspaces are dynamic by default. See [Outputs](/umbriel/outputs) for dynamic
 behavior and fixed workspace lists. See
-[Workspace rules](outputs.md#workspace-rules) for per-workspace layout
+[Workspace rules](/umbriel/outputs#workspace-rules) for per-workspace layout
 overrides.
 
 ## Colors
@@ -169,7 +169,7 @@ saturation = 1.1  # 0.0-2.0
 ```
 
 `enabled` is the master switch. Individual surfaces must still opt in through
-[window rules](rules.md) or [layer rules](rules.md#layer-rules).
+[window rules](/umbriel/rules) or [layer rules](/umbriel/rules#layer-rules).
 Blur only renders where a surface is transparent. Sampling remains confined to
 the surface's owning output when a window overflows into a neighbouring output.
 
@@ -217,7 +217,7 @@ workspace_background = "#00000044"
 ### Open and navigate
 
 The overview shows every workspace on every output. Press `Mod+O` by default,
-or use one of the [overview actions](keybinds.md#overview-actions).
+or use one of the [overview actions](/umbriel/keybinds#overview-actions).
 
 Click a window to focus it, middle-click to close it, or drag it to another
 workspace. Use the wheel, arrow keys, or a 3-finger swipe to move through the
@@ -296,7 +296,7 @@ consumes that space. Existing windows retain their pixel heights, and the
 dropped window fills the remainder apart from the configured inter-window gap.
 
 Layout fields can be overridden per-workspace; see
-[Workspace Rules](outputs.md#workspace-rules).
+[Workspace Rules](/umbriel/outputs#workspace-rules).
 
 ## Input
 

--- a/src/content/docs/umbriel/outputs.mdx
+++ b/src/content/docs/umbriel/outputs.mdx
@@ -76,7 +76,7 @@ monitor in that direction. `window-move-to-output-*` and
 the adjacent monitor's active workspace. `workspace-move-to-output-*` instead
 creates a new workspace on the adjacent monitor and moves every window of the
 active workspace into it, preserving column order and widths. See
-[keybinds.md](keybinds.md) for the full list and their exact semantics.
+[Keybinds](/umbriel/keybinds) for the full list and their exact semantics.
 
 ## Multi-monitor example
 


### PR DESCRIPTION
I noticed the links in the umbriel docs does not work.
I didn't fix the "design/overview-rendering.md" and "design/configuration-reload.md" links because I couldn't find where they are supposed to point.